### PR TITLE
Fixe d.ts filepath and update README about Swift/ObjC bridging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Keychain Wrapper for React Native.
 
 - [react-native-keychain-q](#react-native-keychain-q)
   - [Getting started](#getting-started)
+    - [Prepare](#prepare)
     - [Mostly automatic installation](#mostly-automatic-installation)
       - [Using React Native >= 0.60](#using-react-native--060)
       - [Using React Native < 0.60 or skip auto-linking](#using-react-native--060-or-skip-auto-linking)
@@ -26,6 +27,20 @@ Keychain Wrapper for React Native.
     - [ErrorCodes](#errorcodes)
 
 ## Getting started
+
+
+### Prepare
+
+**Since the native code for this module is written in Swift, you need to add a bridging-header.**
+
+Because it includes Swift code, you need to use both Objective-C and Swift.
+Don't worry. Just add bridging-header file.
+
+https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_objective-c_into_swift
+
+1. Add some Swift file(e.g. Empty.Swift) in your xcode project.
+2. Xcode offers to create this header.
+3. If you accept, Xcode creates the bridging header file and automatically configures build settings.
 
 using yarn:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Keychain Wrapper for React Native.
 - [react-native-keychain-q](#react-native-keychain-q)
   - [Getting started](#getting-started)
     - [Prepare](#prepare)
+    - [Installation](#installation)
     - [Mostly automatic installation](#mostly-automatic-installation)
       - [Using React Native >= 0.60](#using-react-native--060)
       - [Using React Native < 0.60 or skip auto-linking](#using-react-native--060-or-skip-auto-linking)
@@ -41,6 +42,8 @@ https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/
 1. Add some Swift file(e.g. Empty.Swift) in your xcode project.
 2. Xcode offers to create this header.
 3. If you accept, Xcode creates the bridging header file and automatically configures build settings.
+
+### Installation
 
 using yarn:
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -182,7 +182,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
-  - react-native-keychain-q (0.0.5):
+  - react-native-keychain-q (0.0.6):
     - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -326,7 +326,7 @@ SPEC CHECKSUMS:
   React-jsi: cb2cd74d7ccf4cffb071a46833613edc79cdf8f7
   React-jsiexecutor: d5525f9ed5f782fdbacb64b9b01a43a9323d2386
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
-  react-native-keychain-q: a5a4134b00ceddf12c0ab2a760942818b5b1f901
+  react-native-keychain-q: 5450fac343a54cbcded40c3889a9ec54c543af97
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-keychain-q",
   "title": "React Native Keychain Q",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Keychain Service API Wrapper for React Native iOS",
   "main": "lib/commonjs/index.js",
   "scripts": {
@@ -74,7 +74,7 @@
   },
   "react-native": "src/index.ts",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
- `bob init` writes a wrong path of types to package.json.
- Add description about Swift and Objective-C bridging to use this module.